### PR TITLE
docs: Clean homepage + Use Cases catalog with external links (open in new tab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,23 +102,23 @@ A curated collection of **65+ frameworks**, **80+ research papers**, and **produ
 
 ### 🏥 Medical Report Analyzer
 Clinical report analysis with AI insights  
-Frameworks: Agno, AutoGen  
+Frameworks: 🧠 Agno • 🤖 AutoGen  
 <a href="https://github.com/LibertFan/AI_Hospital" target="_blank" rel="noopener noreferrer">Code ↗</a> · <a href="https://aws-samples.github.io/amazon-bedrock-agents-healthcare-lifesciences/" target="_blank" rel="noopener noreferrer">Guide ↗</a>
 
 </td>
 <td>
 
-### 💹 Algorithmic Trading Bot
+### 💰 Algorithmic Trading Bot
 Automated trading with real-time analysis  
-Frameworks: CrewAI, AutoGen  
+Frameworks: 🏢 CrewAI • 🤖 AutoGen  
 <a href="https://github.com/AI4Finance-Foundation/FinRobot" target="_blank" rel="noopener noreferrer">Code ↗</a> · <a href="https://www.youtube.com/watch?v=izW4abxIWe8" target="_blank" rel="noopener noreferrer">Guide ↗</a>
 
 </td>
 <td>
 
-### 🧑‍💼 Recruitment Pipeline Automation
+### 👨‍💼 Recruitment Pipeline Automation
 End-to-end hiring workflow automation  
-Frameworks: CrewAI  
+Frameworks: 🏢 CrewAI  
 <a href="https://www.make.com/en/how-to-guides/ai-recruiting-agent" target="_blank" rel="noopener noreferrer">Code/Guide ↗</a> · <a href="https://www.uipath.com/solutions/department/hr-automation" target="_blank" rel="noopener noreferrer">Guide ↗</a>
 
 </td>
@@ -126,12 +126,14 @@ Frameworks: CrewAI
 
 ### 🔎 Multi-Agent Research System
 Collaborative research with synthesis  
-Frameworks: Agno, AutoGen  
+Frameworks: 🧠 Agno • 🤖 AutoGen  
 <a href="https://github.com/microsoft/ai-agents-for-beginners" target="_blank" rel="noopener noreferrer">Code ↗</a> · <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Guide ↗</a>
 
 </td>
 </tr>
 </table>
+
+**→ [View All Use Cases](catalog/use-cases.md)** — 40+ industry applications with framework mapping
 
 ---
 
@@ -170,3 +172,286 @@ Frameworks: Agno, AutoGen
 
 ---
 
+## 🧪 **Categories** — *By Capability*
+
+<table>
+<tr>
+<td width="50%">
+
+### 👥 **Multi-Agent Systems**
+| Framework | Specialty | Stars |
+|-----------|-----------|-------|
+| <a href="https://github.com/crewAIInc/crewAI" target="_blank" rel="noopener noreferrer">CrewAI ↗</a> | Role-based teams | 35K |
+| <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">AutoGen ↗</a> | Conversation | 48K |
+| <a href="https://github.com/geekan/MetaGPT" target="_blank" rel="noopener noreferrer">MetaGPT ↗</a> | Software company | 58K |
+| <a href="https://github.com/OpenBMB/ChatDev" target="_blank" rel="noopener noreferrer">ChatDev ↗</a> | Development team | 27K |
+| <a href="https://github.com/ag2ai/fastagency" target="_blank" rel="noopener noreferrer">FastAgency ↗</a> | AG2 production | 1.8K |
+| <a href="https://github.com/openai/swarm" target="_blank" rel="noopener noreferrer">OpenAI Swarm ↗</a> | Lightweight | 15K |
+
+**🚀 Quick Start**: [Multi-Agent Patterns Guide](patterns/multi-agent-patterns.md)
+
+### 💻 **Coding & Software Engineering**
+| Framework | Specialty | Stars |
+|-----------|-----------|-------|
+| <a href="https://github.com/All-Hands-AI/OpenHands" target="_blank" rel="noopener noreferrer">OpenDevin ↗</a> | Autonomous coding | 61K |
+| <a href="https://github.com/KillianLucas/open-interpreter" target="_blank" rel="noopener noreferrer">Open Interpreter ↗</a> | Local execution | 60K |
+| <a href="https://github.com/gpt-engineer-org/gpt-engineer" target="_blank" rel="noopener noreferrer">GPT Engineer ↗</a> | Code generation | 55K |
+| <a href="https://github.com/stitionai/devika" target="_blank" rel="noopener noreferrer">Devika ↗</a> | Open source Devin | 19K |
+| <a href="https://github.com/BloopAI/bloop" target="_blank" rel="noopener noreferrer">Bloop ↗</a> | Code search | 10K |
+
+**🚀 Quick Start**: [Coding Agents Deep Dive](catalog/coding-agents-deep-dive.md)
+
+### 🖥️ **Computer Use (Desktop/Web)**
+| Framework | Specialty | Type |
+|-----------|-----------|------|
+| Claude Computer Use | Desktop control | Commercial |
+| OpenAI Operator | Web automation | Commercial |
+| <a href="https://github.com/nanobrowser/nanobrowser" target="_blank" rel="noopener noreferrer">Nanobrowser ↗</a> | Web navigation | 7.1K |
+| <a href="https://github.com/Sanster/UI-TARS" target="_blank" rel="noopener noreferrer">UI-TARS ↗</a> | GUI automation | 6.5K |
+| <a href="https://github.com/Skyvern-AI/skyvern" target="_blank" rel="noopener noreferrer">Skyvern ↗</a> | Web extraction | 4K |
+
+**🚀 Quick Start**: [Computer Use Agents Guide](catalog/computer-use-agents.md)
+
+</td>
+<td width="50%">
+
+### 🔗 **RAG & Data Agents**
+| Framework | Specialty | Stars |
+|-----------|-----------|-------|
+| <a href="https://github.com/langchain-ai/langchain" target="_blank" rel="noopener noreferrer">LangChain ↗</a> | Tool integration | 113K |
+| <a href="https://github.com/run-llama/llama_index" target="_blank" rel="noopener noreferrer">LlamaIndex ↗</a> | Data applications | 43K |
+| <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">LangGraph ↗</a> | Stateful workflows | 8K |
+| <a href="https://github.com/eosphoros-ai/DB-GPT" target="_blank" rel="noopener noreferrer">DB-GPT ↗</a> | Database queries | 17K |
+| <a href="https://github.com/pgalko/BambooAI" target="_blank" rel="noopener noreferrer">BambooAI ↗</a> | Data exploration | 2.3K |
+| <a href="https://github.com/HumanSignal/Adala" target="_blank" rel="noopener noreferrer">Adala ↗</a> | Data labeling | 2K |
+
+**🚀 Quick Start**: [Getting Started Guide](guides/getting-started.md)
+
+### 🏢 **Enterprise & Production**
+| Framework | Specialty | Maturity |
+|-----------|-----------|----------|
+| <a href="https://github.com/microsoft/semantic-kernel" target="_blank" rel="noopener noreferrer">Semantic Kernel ↗</a> | Enterprise SDK | Production |
+| Google ADK | Workflow agents | Production |
+| Vellum AI | Governance platform | Production |
+| <a href="https://github.com/e2b-dev/e2b" target="_blank" rel="noopener noreferrer">E2B Sandbox ↗</a> | Secure runtime | Production |
+| <a href="https://github.com/eidolon-ai/eidolon" target="_blank" rel="noopener noreferrer">Eidolon ↗</a> | Agent server | Production |
+
+**🚀 Quick Start**: [Enterprise Deployment](guides/enterprise-deployment.md)
+
+### 💻 **CLI & Terminal**
+| Framework | Specialty | Type |
+|-----------|-----------|------|
+| Qodo Command | CI/CD workflows | Commercial |
+| <a href="https://github.com/continuedev/continue" target="_blank" rel="noopener noreferrer">Continue ↗</a> | VS Code agent | 28K |
+| Goose CLI | Local terminal | Open source |
+| Amazon Q CLI | AWS operations | Commercial |
+
+**🚀 Quick Start**: [CLI Agents Guide](catalog/cli-agents.md)
+
+</td>
+</tr>
+</table>
+
+---
+
+## 📈 **Repository Stats**
+
+> 🔄 *Data refreshed weekly via automation*
+
+<table>
+<tr>
+<td align="center"><strong>65+</strong><br/>Frameworks</td>
+<td align="center"><strong>1M+</strong><br/>Total Stars</td>
+<td align="center"><strong>80+</strong><br/>Research Papers</td>
+<td align="center"><strong>6</strong><br/>Major Categories</td>
+<td align="center"><strong>8+</strong><br/>Evaluation Benchmarks</td>
+</tr>
+</table>
+
+---
+
+## 🧪 **Framework Selection** — *Choose the Right Tool*
+
+### 🔍 **Interactive Comparison**
+➤ **[Compare Frameworks](compare/index.html)** — Filter by capability, maturity, language, deployment
+
+### 🔧 **Get Recommendations**
+```bash
+# Get personalized recommendations
+python scripts/recommend.py --use_case coding --experience intermediate --deployment cloud
+```
+
+### 📋 **Decision Matrix**
+| **If you need...** | **Choose** | **Alternative** | **Enterprise** |
+|-------------------|------------|-----------------|----------------|
+| **Multi-agent collaboration** | CrewAI | AutoGen | Semantic Kernel |
+| **Code generation** | Open Interpreter | OpenDevin | GitHub Copilot |
+| **Desktop automation** | Claude Computer Use | OpenAI Operator | UI-TARS |
+| **RAG applications** | LangChain | LlamaIndex | Azure OpenAI |
+| **Data exploration** | BambooAI | GPT Researcher | Custom solution |
+| **Code search** | Bloop | GitHub Copilot | Sourcegraph Cody |
+
+---
+
+## 🎆 **Featured Content**
+
+<table>
+<tr>
+<td width="33%">
+
+### 🔥 **Hot Topics**
+- 🖥️ **[Computer Use Agents](catalog/computer-use-agents.md)**  
+  *Desktop & web automation*
+- 🤝 **[Multi-Agent Patterns](patterns/multi-agent-patterns.md)**  
+  *Collaboration architectures*
+- 🏢 **[Enterprise Deployment](guides/enterprise-deployment.md)**  
+  *Production-ready patterns*
+
+</td>
+<td width="33%">
+
+### 🎯 **Practical Guides**
+- 💻 **[Coding Agents Deep Dive](catalog/coding-agents-deep-dive.md)**  
+  *OpenDevin, Open Interpreter, GPT Engineer*
+- 📈 **[Agent Evaluation](catalog/evaluation.md)**  
+  *AgentBench, WebArena, SWE-bench*
+- 🔌 **[MCP Integration](catalog/mcp.md)**  
+  *Model Context Protocol*
+
+</td>
+<td width="33%">
+
+### 🔗 **Developer Tools**
+- 💱 **[CLI Agents](catalog/cli-agents.md)**  
+  *Terminal automation*
+- 🔧 **[Tool Integrations](catalog/tool-integrations.md)**  
+  *API connectors + specialized tools*
+- ⚙️ **[Scripts & Automation](scripts/)**  
+  *Maintenance utilities*
+
+</td>
+</tr>
+</table>
+
+---
+
+## 📚 **Research & Academic Work**
+
+### 🏆 **Industry Research** (2024-2025)
+- **Google/DeepMind**: Chain-of-Agents, Windows Agent Arena, Melting Pot
+- **Microsoft**: AutoGen/AG2 framework, AutoGen Studio
+- **Anthropic**: Claude Computer Use, Model Context Protocol (MCP)
+- **OpenAI**: Computer-Using Agent/Operator, Agents SDK
+- **MIT/CSAIL**: Automated Interpretability, AI safety frameworks
+
+### 📝 **Academic Papers** (80+ papers)
+➤ **[Browse Research Papers](research/papers.md)** — Foundational surveys, multi-agent collaboration, evaluation frameworks
+
+---
+
+## 📊 **Evaluation & Benchmarking**
+
+<table>
+<tr>
+<td width="33%">
+
+### 🏁 **Major Benchmarks**
+- **[AgentBench](evaluation/agentbench.md)** — 8 environments
+- **[WebArena](evaluation/webarena.md)** — Web navigation
+- **[SWE-bench](evaluation/swebench.md)** — Code solving
+- **[τ-Bench](catalog/evaluation.md)** — Real-world reliability
+
+</td>
+<td width="33%">
+
+### 🛠️ **Tools & Platforms**
+- **[AgentOps](https://github.com/AgentOps-AI/agentops)** — Monitoring
+- **[E2B](https://github.com/e2b-dev/e2b)** — Sandboxing
+- **[LangSmith](https://smith.langchain.com/)** — LangChain eval
+
+</td>
+<td width="33%">
+
+### 📊 **Performance Data**
+- **GPT-4 + CoT**: 50% (AgentBench)
+- **Devin**: 13.86% (SWE-bench)
+- **WebArena**: 35.8% (GPT-4)
+
+</td>
+</tr>
+</table>
+
+**🚀 Complete Guide**: [Agent Evaluation & Benchmarking](catalog/evaluation.md)
+
+---
+
+## 🤝 **Contributing**
+
+We welcome high-quality contributions! 🙏
+
+### 🎯 **How to Contribute**
+- **🆕 New Framework**: Use our [issue template](.github/ISSUE_TEMPLATE/add-framework.yml)
+- **📝 Documentation**: Submit PRs with our [PR template](.github/PULL_REQUEST_TEMPLATE.md)
+- **🔬 Research Papers**: Add to [research/papers.md](research/papers.md)
+- **📊 Case Studies**: Share real-world implementations
+- **🧩 Use Cases**: Propose industry applications via [Use Cases](catalog/use-cases.md)
+
+### 🛡️ **Quality Standards**
+- **500+ GitHub stars** OR backing from established organization
+- **Active maintenance** (commits within 12 months)
+- **Clear documentation** and examples
+- **Unique value proposition** (not a duplicate/fork)
+
+**🚀 Full Guide**: [Contributing Guidelines](CONTRIBUTING.md)
+
+---
+
+## 🎥 **Success Stories**
+
+### 🏢 **Enterprise Adoptions**
+- **Block (Square)** — MCP for financial services
+- **Apollo GraphQL** — API development assistance  
+- **Replit** — Agent-powered coding
+- **Zed Editor** — MCP integration
+
+### 🏆 **Community Highlights**
+- **GPT Researcher**: #1 by Carnegie Mellon's DeepResearchGym
+- **CrewAI**: Fastest growing (0→35K stars in 18 months)
+- **AutoGPT**: Most forked autonomous agent (177K stars)
+- **LangChain**: Largest ecosystem (113K stars)
+
+---
+
+## 📡 Stay Connected
+
+- **Follow Bunty**: https://www.linkedin.com/in/bunty-shah/
+- **Watch Repository**: https://github.com/buntys2010/awesome-ai-agents/subscription
+- **Start a Discussion**: https://github.com/buntys2010/awesome-ai-agents/discussions
+
+---
+
+## 📜 **License**
+
+[![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
+
+**Creative Commons Zero v1.0 Universal** — Use freely, no attribution required
+
+---
+
+## 🙏 **Acknowledgments**
+
+Special thanks to the AI community:
+- **Framework maintainers** pushing the boundaries of AI agents
+- **Research institutions** (MIT, Stanford, CMU) advancing the science
+- **Industry labs** (Google, Microsoft, OpenAI, Anthropic) driving innovation
+- **Open source contributors** making this knowledge accessible
+
+---
+
+<div align="center">
+
+**🎆 Curated with ❤️ by the AI research community**
+
+*⭐ Star this repo to stay updated with the latest AI agent frameworks and research!*
+
+</div>

--- a/README.md
+++ b/README.md
@@ -84,13 +84,54 @@ A curated collection of **65+ frameworks**, **80+ research papers**, and **produ
 ## 🔥 **What's New** — *Latest Updates*
 
 **October 2025 Updates:**
-- ✨ **Use Cases** — New catalog by industry and framework patterns (rewritten summaries with Code/Notebook links)
+- ✨ **Use Cases** — Now organized by use case first with framework mapping, plus external Code/Guide links
 - ✨ **Computer Use Agents** — Claude Computer Use, OpenAI Operator, open-source frameworks
 - 💻 **CLI & Terminal Agents** — Developer workflow automation (Qodo Command, Goose CLI)
 - 🏢 **Enterprise Platforms** — Google ADK, Vellum AI, production deployment guides
 - 🔧 **Specialized Tools** — Adala (data labeling), BambooAI (data exploration), Bloop (code search)
 - 🧪 **Interactive Comparison** — Filter frameworks by capability, maturity, language
 - 📈 **Automated Maintenance** — Weekly star refresh, link checking, what's new curation
+
+---
+
+## 🌟 **Use Case Spotlight**
+
+<table>
+<tr>
+<td>
+
+### 🏥 Medical Report Analyzer
+Clinical report analysis with AI insights  
+Frameworks: Agno, AutoGen  
+<a href="https://github.com/LibertFan/AI_Hospital" target="_blank" rel="noopener noreferrer">Code ↗</a> · <a href="https://aws-samples.github.io/amazon-bedrock-agents-healthcare-lifesciences/" target="_blank" rel="noopener noreferrer">Guide ↗</a>
+
+</td>
+<td>
+
+### 💹 Algorithmic Trading Bot
+Automated trading with real-time analysis  
+Frameworks: CrewAI, AutoGen  
+<a href="https://github.com/AI4Finance-Foundation/FinRobot" target="_blank" rel="noopener noreferrer">Code ↗</a> · <a href="https://www.youtube.com/watch?v=izW4abxIWe8" target="_blank" rel="noopener noreferrer">Guide ↗</a>
+
+</td>
+<td>
+
+### 🧑‍💼 Recruitment Pipeline Automation
+End-to-end hiring workflow automation  
+Frameworks: CrewAI  
+<a href="https://www.make.com/en/how-to-guides/ai-recruiting-agent" target="_blank" rel="noopener noreferrer">Code/Guide ↗</a> · <a href="https://www.uipath.com/solutions/department/hr-automation" target="_blank" rel="noopener noreferrer">Guide ↗</a>
+
+</td>
+<td>
+
+### 🔎 Multi-Agent Research System
+Collaborative research with synthesis  
+Frameworks: Agno, AutoGen  
+<a href="https://github.com/microsoft/ai-agents-for-beginners" target="_blank" rel="noopener noreferrer">Code ↗</a> · <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Guide ↗</a>
+
+</td>
+</tr>
+</table>
 
 ---
 
@@ -122,169 +163,6 @@ A curated collection of **65+ frameworks**, **80+ research papers**, and **produ
 | <a href="https://github.com/reworkd/AgentGPT" target="_blank" rel="noopener noreferrer">AgentGPT ↗</a> | 35K | Web platform |
 | <a href="https://github.com/OpenBMB/ChatDev" target="_blank" rel="noopener noreferrer">ChatDev ↗</a> | 27K | Virtual company |
 | <a href="https://github.com/stanfordnlp/dspy" target="_blank" rel="noopener noreferrer">DSPy ↗</a> | 27K | Prompt optimization |
-
-</td>
-</tr>
-</table>
-
----
-
-## 🧪 **Categories** — *By Capability*
-
-<table>
-<tr>
-<td width="50%">
-
-### 👥 **Multi-Agent Systems**
-| Framework | Specialty | Stars |
-|-----------|-----------|-------|
-| <a href="https://github.com/crewAIInc/crewAI" target="_blank" rel="noopener noreferrer">CrewAI ↗</a> | Role-based teams | 35K |
-| <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">AutoGen ↗</a> | Conversation | 48K |
-| <a href="https://github.com/geekan/MetaGPT" target="_blank" rel="noopener noreferrer">MetaGPT ↗</a> | Software company | 58K |
-| <a href="https://github.com/OpenBMB/ChatDev" target="_blank" rel="noopener noreferrer">ChatDev ↗</a> | Development team | 27K |
-| <a href="https://github.com/ag2ai/fastagency" target="_blank" rel="noopener noreferrer">FastAgency ↗</a> | AG2 production | 1.8K |
-| <a href="https://github.com/openai/swarm" target="_blank" rel="noopener noreferrer">OpenAI Swarm ↗</a> | Lightweight | 15K |
-
-**🚀 Quick Start**: [Multi-Agent Patterns Guide](patterns/multi-agent-patterns.md)
-
-### 💻 **Coding & Software Engineering**
-| Framework | Specialty | Stars |
-|-----------|-----------|-------|
-| <a href="https://github.com/All-Hands-AI/OpenHands" target="_blank" rel="noopener noreferrer">OpenDevin ↗</a> | Autonomous coding | 61K |
-| <a href="https://github.com/KillianLucas/open-interpreter" target="_blank" rel="noopener noreferrer">Open Interpreter ↗</a> | Local execution | 60K |
-| <a href="https://github.com/gpt-engineer-org/gpt-engineer" target="_blank" rel="noopener noreferrer">GPT Engineer ↗</a> | Code generation | 55K |
-| <a href="https://github.com/stitionai/devika" target="_blank" rel="noopener noreferrer">Devika ↗</a> | Open source Devin | 19K |
-| <a href="https://github.com/BloopAI/bloop" target="_blank" rel="noopener noreferrer">Bloop ↗</a> | Code search | 10K |
-
-**🚀 Quick Start**: [Coding Agents Deep Dive](catalog/coding-agents-deep-dive.md)
-
-### 🖥️ **Computer Use (Desktop/Web)**
-| Framework | Specialty | Type |
-|-----------|-----------|------|
-| Claude Computer Use | Desktop control | Commercial |
-| OpenAI Operator | Web automation | Commercial |
-| <a href="https://github.com/nanobrowser/nanobrowser" target="_blank" rel="noopener noreferrer">Nanobrowser ↗</a> | Web navigation | 7.1K |
-| <a href="https://github.com/Sanster/UI-TARS" target="_blank" rel="noopener noreferrer">UI-TARS ↗</a> | GUI automation | 6.5K |
-| <a href="https://github.com/Skyvern-AI/skyvern" target="_blank" rel="noopener noreferrer">Skyvern ↗</a> | Web extraction | 4K |
-
-**🚀 Quick Start**: [Computer Use Agents Guide](catalog/computer-use-agents.md)
-
-</td>
-<td width="50%">
-
-### 🔗 **RAG & Data Agents**
-| Framework | Specialty | Stars |
-|-----------|-----------|-------|
-| <a href="https://github.com/langchain-ai/langchain" target="_blank" rel="noopener noreferrer">LangChain ↗</a> | Tool integration | 113K |
-| <a href="https://github.com/run-llama/llama_index" target="_blank" rel="noopener noreferrer">LlamaIndex ↗</a> | Data applications | 43K |
-| <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">LangGraph ↗</a> | Stateful workflows | 8K |
-| <a href="https://github.com/eosphoros-ai/DB-GPT" target="_blank" rel="noopener noreferrer">DB-GPT ↗</a> | Database queries | 17K |
-| <a href="https://github.com/pgalko/BambooAI" target="_blank" rel="noopener noreferrer">BambooAI ↗</a> | Data exploration | 2.3K |
-| <a href="https://github.com/HumanSignal/Adala" target="_blank" rel="noopener noreferrer">Adala ↗</a> | Data labeling | 2K |
-
-**🚀 Quick Start**: [Getting Started Guide](guides/getting-started.md)
-
-### 🏢 **Enterprise & Production**
-| Framework | Specialty | Maturity |
-|-----------|-----------|----------|
-| <a href="https://github.com/microsoft/semantic-kernel" target="_blank" rel="noopener noreferrer">Semantic Kernel ↗</a> | Enterprise SDK | Production |
-| Google ADK | Workflow agents | Production |
-| Vellum AI | Governance platform | Production |
-| <a href="https://github.com/e2b-dev/e2b" target="_blank" rel="noopener noreferrer">E2B Sandbox ↗</a> | Secure runtime | Production |
-| <a href="https://github.com/eidolon-ai/eidolon" target="_blank" rel="noopener noreferrer">Eidolon ↗</a> | Agent server | Production |
-
-**🚀 Quick Start**: [Enterprise Deployment](guides/enterprise-deployment.md)
-
-### 💻 **CLI & Terminal**
-| Framework | Specialty | Type |
-|-----------|-----------|------|
-| Qodo Command | CI/CD workflows | Commercial |
-| <a href="https://github.com/continuedev/continue" target="_blank" rel="noopener noreferrer">Continue ↗</a> | VS Code agent | 28K |
-| Goose CLI | Local terminal | Open source |
-| Amazon Q CLI | AWS operations | Commercial |
-
-**🚀 Quick Start**: [CLI Agents Guide](catalog/cli-agents.md)
-
-</td>
-</tr>
-</table>
-
----
-
-## 📈 **Repository Stats**
-
-> 🔄 *Data refreshed weekly via automation*
-
-<table>
-<tr>
-<td align="center"><strong>65+</strong><br/>Frameworks</td>
-<td align="center"><strong>1M+</strong><br/>Total Stars</td>
-<td align="center"><strong>80+</strong><br/>Research Papers</td>
-<td align="center"><strong>6</strong><br/>Major Categories</td>
-<td align="center"><strong>8+</strong><br/>Evaluation Benchmarks</td>
-</tr>
-</table>
-
----
-
-## 🧪 **Framework Selection** — *Choose the Right Tool*
-
-### 🔍 **Interactive Comparison**
-➤ **[Compare Frameworks](compare/index.html)** — Filter by capability, maturity, language, deployment
-
-### 🔧 **Get Recommendations**
-```bash
-# Get personalized recommendations
-python scripts/recommend.py --use_case coding --experience intermediate --deployment cloud
-```
-
-### 📋 **Decision Matrix**
-| **If you need...** | **Choose** | **Alternative** | **Enterprise** |
-|-------------------|------------|-----------------|----------------|
-| **Multi-agent collaboration** | CrewAI | AutoGen | Semantic Kernel |
-| **Code generation** | Open Interpreter | OpenDevin | GitHub Copilot |
-| **Desktop automation** | Claude Computer Use | OpenAI Operator | UI-TARS |
-| **RAG applications** | LangChain | LlamaIndex | Azure OpenAI |
-| **Data exploration** | BambooAI | GPT Researcher | Custom solution |
-| **Code search** | Bloop | GitHub Copilot | Sourcegraph Cody |
-
----
-
-## 🎆 **Featured Content**
-
-<table>
-<tr>
-<td width="33%">
-
-### 🔥 **Hot Topics**
-- 🖥️ **[Computer Use Agents](catalog/computer-use-agents.md)**  
-  *Desktop & web automation*
-- 🤝 **[Multi-Agent Patterns](patterns/multi-agent-patterns.md)**  
-  *Collaboration architectures*
-- 🏢 **[Enterprise Deployment](guides/enterprise-deployment.md)**  
-  *Production-ready patterns*
-
-</td>
-<td width="33%">
-
-### 🎯 **Practical Guides**
-- 💻 **[Coding Agents Deep Dive](catalog/coding-agents-deep-dive.md)**  
-  *OpenDevin, Open Interpreter, GPT Engineer*
-- 📈 **[Agent Evaluation](catalog/evaluation.md)**  
-  *AgentBench, WebArena, SWE-bench*
-- 🔌 **[MCP Integration](catalog/mcp.md)**  
-  *Model Context Protocol*
-
-</td>
-<td width="33%">
-
-### 🔗 **Developer Tools**
-- 💱 **[CLI Agents](catalog/cli-agents.md)**  
-  *Terminal automation*
-- 🔧 **[Tool Integrations](catalog/tool-integrations.md)**  
-  *API connectors + specialized tools*
-- ⚙️ **[Scripts & Automation](scripts/)**  
-  *Maintenance utilities*
 
 </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated collection of **65+ frameworks**, **80+ research papers**, and **produ
 ## 🔥 **What's New** — *Latest Updates*
 
 **October 2025 Updates:**
+- ✨ **Use Cases** — New catalog by industry and framework patterns (rewritten summaries with Code/Notebook links)
 - ✨ **Computer Use Agents** — Claude Computer Use, OpenAI Operator, open-source frameworks
 - 💻 **CLI & Terminal Agents** — Developer workflow automation (Qodo Command, Goose CLI)
 - 🏢 **Enterprise Platforms** — Google ADK, Vellum AI, production deployment guides
@@ -291,6 +292,3 @@ python scripts/recommend.py --use_case coding --experience intermediate --deploy
 
 ---
 
-## 🔄 **All Categories**
-
-... (unchanged sections below retained for brevity)

--- a/catalog/use-cases-autogen.md
+++ b/catalog/use-cases-autogen.md
@@ -1,0 +1,83 @@
+# 🤖 AutoGen Use Cases
+
+_Last reviewed: October 2025_
+
+AutoGen/AG2 specializes in multi-agent conversation and collaboration. Each use case demonstrates different patterns of agent interaction and coordination.
+
+## 💻 Code Generation & Development
+
+| Use Case | Industry | Description | Notebook / Guide |
+|---|---|---|---|
+| Task Solving with Code Generation & Debugging | Software Development | Automated task-solving by generating, executing, debugging code | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Code Generation with Retrieval Augmented Agents | Software Development | Generate code and answer questions using retrieval methods | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Code Generation with Qdrant-based Retrieval | Software Development | Enhanced retrieval-augmented agent performance with Qdrant | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Auto Code Generation with Human Feedback | Software Development | Code generation, execution, debugging with human feedback | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+
+## 🤝 Multi-Agent Collaboration
+
+| Use Case | Industry | Description | Notebook / Guide |
+|---|---|---|---|
+| Group Chat Task Solving (3 members + manager) | Collaboration | Group task-solving via multi-agent collaboration | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Data Visualization via Group Chat | Data Analysis | Multi-agent collaboration for data visualizations | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Complex Task Solving (6 members + manager) | Collaboration | Solve complex tasks with larger collaborative groups | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Coding & Planning Agent Collaboration | Planning & Development | Combine coding and planning agents effectively | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Task Solving with Graph Transition Paths | Collaboration | Use predefined transition paths in graphs | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Group Chat as Inner-Monologue (SocietyOfMind) | Cognitive Sciences | Simulate inner-monologue for problem-solving | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Custom Speaker Selection in Group Chat | Collaboration | Implement custom speaker selection functions | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+
+## 🔄 Sequential & Nested Workflows
+
+| Use Case | Industry | Description | Notebook / Guide |
+|---|---|---|---|
+| Sequential Task Solving (Single Agent Init) | Workflow Automation | Sequential task-solving with single initiating agent | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Async Sequential Task Solving | Workflow Automation | Asynchronous task-solving in sequences | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Sequential Tasks (Different Agent Init) | Workflow Automation | Different agents initiating sequential tasks | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Complex Tasks with Nested Chats | Problem Solving | Use nested chats for hierarchical problems | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Sequential Nested Chats | Problem Solving | Sequential task-solving using nested chats | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| OptiGuide Supply Chain Optimization | Supply Chain | Solve optimization with nested chats + safeguard agent | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Conversational Chess with Tool Use | Gaming | Chess playing with nested chats and integrated tools | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+
+## 🔧 Tools & Integration
+
+| Use Case | Industry | Description | Notebook / Guide |
+|---|---|---|---|
+| Web Search for Task Solving | Information Retrieval | Search web to gather information for tasks | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Tools as Functions | Tool Integration | Use pre-provided tools as callable functions | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Sync & Async Function Calling | Tool Integration | Synchronous and asynchronous tool usage | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| LangChain Tools Integration | Language Processing | Leverage LangChain tools for task-solving | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| RAG Group Chat | Collaboration | Group chat with Retrieval Augmented Generation | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Dynamic Function Updates | Development Tools | Modify agent functions during conversations | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Agent Chat with Whisper | Audio Processing | Transcription and translation using Whisper | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Web Browsing with Agents | Information Retrieval | Configure agents for web browsing and retrieval | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| SQL Query Generation | Database Management | Natural language to SQL query conversion | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Web Scraping with Apify | Data Gathering | Web scraping techniques using Apify | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Domain Crawling with Spider API | Data Gathering | Crawl entire domains using Spider API | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+
+## 🎯 Application & Deployment
+
+| Use Case | Industry | Description | Notebook / Guide |
+|---|---|---|---|
+| Continual Learning from New Data | Machine Learning | Continuously learn from new data inputs | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| OptiGuide Multi-Tool Integration | Supply Chain | Coding, tool use, safeguarding for optimization | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| AutoAnny Discord Bot | Communication Tools | Discord bot development using AutoGen | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+
+## 🎭 Advanced Patterns
+
+| Use Case | Industry | Description | Notebook / Guide |
+|---|---|---|---|
+| Multi-Agent System Building | AI Development | Automatically build multi-agent systems | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Agent Library System Building | AI Development | Build systems from pre-defined agent libraries | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| AgentOps Monitoring | Monitoring & Analytics | Track LLM calls, tool usage, actions, errors | <a href="https://github.com/AgentOps-AI/agentops" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| API Configuration Management | API Management | Manage API configurations effectively | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Cost Calculation & Optimization | Cost Management | Track token usage and estimate LLM costs | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+
+---
+
+### 🔧 Implementation Notes
+- AutoGen excels at conversational multi-agent systems
+- Use GroupChat for team collaboration scenarios
+- Implement nested chats for hierarchical problem solving
+- Add human-in-the-loop for complex decision making
+- Monitor costs and token usage in production
+
+**← [Back to Use Cases](use-cases.md)**

--- a/catalog/use-cases-crewai.md
+++ b/catalog/use-cases-crewai.md
@@ -1,0 +1,67 @@
+# 🏢 CrewAI Use Cases
+
+_Last reviewed: October 2025_
+
+CrewAI specializes in role-based multi-agent teams. Each use case shows how different agent roles collaborate to solve business problems.
+
+## 💬 Communication & Productivity
+
+| Use Case | Industry | Description | Code / Guide |
+|---|---|---|---|
+| Email Auto Responder Flow | Communication | Automate email responses with predefined criteria and workflows | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Meeting Assistant Flow | Productivity | Organize meetings, scheduling, and agenda preparation | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Meeting Preparation Agent | Productivity | Organize materials and set agendas for effective meetings | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+
+## 👥 HR & Recruitment
+
+| Use Case | Industry | Description | Code / Guide |
+|---|---|---|---|
+| Self Evaluation Loop Flow | Human Resources | Facilitate self-assessment processes within organizations | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Job Posting Generator | Recruitment | Create job postings by analyzing requirements | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Recruitment Workflow | Recruitment | Streamline hiring process automation | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Match Profile to Positions | Recruitment | Match candidate profiles to suitable positions | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+
+## 💰 Sales & Marketing
+
+| Use Case | Industry | Description | Code / Guide |
+|---|---|---|---|
+| Lead Score Flow | Sales | Evaluate and score leads for outreach prioritization | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Marketing Strategy Generator | Marketing | Develop strategies using market trends and audience data | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Stock Analysis Tool | Finance | Analyze stock market data for financial decisions | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+
+## 🌍 Content & Social Media
+
+| Use Case | Industry | Description | Code / Guide |
+|---|---|---|---|
+| Instagram Post Generator | Social Media | Generate and schedule Instagram posts automatically | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Landing Page Generator | Web Development | Automate landing page creation for websites | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+
+## 🎮 Creative & Entertainment
+
+| Use Case | Industry | Description | Code / Guide |
+|---|---|---|---|
+| Game Builder Crew | Game Development | Assist in game development automation | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Trip Planner | Travel | Plan trips with itinerary organization | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Surprise Trip Planner | Travel | Plan surprise trips with destinations and activities | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Write a Book with Flows | Creative Writing | Assist authors with structured writing workflows | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Screenplay Writer | Creative Writing | Aid screenplay writing with templates and guidance | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+
+## 🔧 Technical & Integration
+
+| Use Case | Industry | Description | Code / Guide |
+|---|---|---|---|
+| Markdown Validator | Documentation | Validate Markdown files for proper formatting | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Meta Quest Knowledge | Knowledge Management | Manage and organize Meta Quest-related knowledge | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| NVIDIA Models Integration | AI Integration | Integrate NVIDIA AI models into workflows | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Starter Template | Development | Starter template for new CrewAI projects | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| CrewAI + LangGraph Integration | AI Integration | Integration between CrewAI and LangGraph | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+
+---
+
+### 🔧 Implementation Notes
+- CrewAI excels at role-based collaboration with clear agent responsibilities
+- Start with 2-3 agents; expand team size based on task complexity
+- Use hierarchical processes for complex workflows
+- Implement quality assurance with reviewer agents
+
+**← [Back to Use Cases](use-cases.md)**

--- a/catalog/use-cases.md
+++ b/catalog/use-cases.md
@@ -6,87 +6,58 @@ A curated catalog of practical AI agent use cases organized by industry and fram
 
 ## 🏭 Industry Use Cases
 
-### 🏥 Healthcare
-- Health Insights Agent — analyzes medical reports and provides insights
-- AI Health Assistant — disease triage and monitoring
-- Claims Automation Agent — insurance claims workflow
-
-### 💰 Finance
-- Automated Trading Bot — real-time market analysis and execution
-- Financial Research Agent — filings, news, and analyst consensus
-- Risk Scoring Agent — portfolio or counterparty risk
-
-### 🎓 Education
-- Virtual Tutor — personalized learning and study plans
-- Content Generator — lesson plans, quizzes, and rubrics
-
-### 🛒 Retail / E-commerce
-- Product Recommendation Agent — preference-based suggestions
-- Personal Shopper — multi-vendor search and fit analysis
-
-### 🧑‍💼 HR / Recruitment
-- Profile-to-Position Matcher — resume parsing and JD alignment
-- Recruitment Workflow — sourcing, screening, outreach
-
-### 🧳 Travel & Hospitality
-- Trip Planner — itineraries, costs, availability, constraints
-- Concierge Agent — bookings, changes, and upsells
-
-### 🏭 Manufacturing
-- Process Monitoring — QC checks, anomaly detection
-- Supplier Intelligence — audits, compliance summaries
-
-### 🔒 Cybersecurity
-- Threat Detection Agent — IOC monitoring and triage
-- Red Team Agent — autonomous adversarial probing
-
-### ⚡ Energy
-- Demand Forecasting — grid optimization
-- Fault Detection — time-series analysis
-
+| Use Case | Sector | Summary | Code / Notebook |
+|---------|--------|---------|-----------------|
+| Medical report insights | Healthcare | Parse and summarize clinical or lab reports with compliance notes | Notebook ↗ |
+| Insurance claims assistant | Healthcare/Insurance | Automate initial triage, document checks, and status updates | Code ↗ |
+| Algorithmic trade executor | Finance | Strategy backtesting + live execution with risk guardrails | Notebook ↗ |
+| Equity research digester | Finance | Aggregate filings, news, and consensus into a brief | Code ↗ |
+| Resume-to-role matcher | HR | Profile parsing + role matching with scoring and reasoning | Notebook ↗ |
+| Candidate outreach pipeline | HR | Generate tailored messages and schedule interviews | Code ↗ |
+| Personal study tutor | Education | Plan lessons, quizzes, and adaptive study schedules | Notebook ↗ |
+| Product recommender | Retail | Suggest items from catalog based on preferences/context | Code ↗ |
+| Red team probe | Cybersecurity | Automated adversarial probing of known endpoints | Code ↗ |
+| IOC alert triage | Cybersecurity | Prioritize and summarize threat intel and alerts | Notebook ↗ |
+| Smart web navigator | Web Automation | Browse, extract, and structure information from sites | Notebook ↗ |
 
 ## 🔧 Framework-specific Examples
 
 ### CrewAI
-- Email Auto Responder Flow — communication efficiency
-- Meeting Assistant — scheduling, agenda prep, notes
-- Lead Scoring — sales prioritization
-- Recruitment Workflow — sourcing to shortlist
-- Marketing Strategy Generator — campaign ideation
+- Communication assistant (email triage, responses)
+- Meeting copilot (agenda, minutes, actions)
+- Lead scoring and prioritization
+- Hiring pipeline automation
+- Trip planning and itinerary builder
 
 ### AutoGen / AG2
-- Group Chat Orchestration — manager + specialists
-- Agentic RAG — retrieval + planning
-- Nested Chats — hierarchical task solving
-- Web Scraping — Apify + Spider API
-- Tool Use — Whisper, SQL, LangChain tools
+- Group-chat orchestration (manager + experts)
+- Agentic RAG (retrieval + critic + synthesis)
+- Nested conversations for sub-tasking
+- Web/tools integration (search, SQL, Whisper)
 
 ### LangGraph
-- Plan-and-Execute — long-horizon task planning
-- Agent Supervisor — hierarchical teams
-- Agentic RAG — adaptive, corrective, self-RAG
-- SQL QA — schema-aware question answering
+- Plan-and-execute templates
+- Supervisor + hierarchical teams
+- Corrective/self-reflective RAG flows
+- SQL QA over enterprise data
 
 ### Agno
-- Support Agent — docs-grounded Q&A
-- Research Scholar — literature surveys with citations
-- Finance Agent — real-time market analysis
-- Media Trend Analysis — influencer and topic mining
-
+- Support assistant over documentation
+- Literature review with citations
+- Finance market snapshot agent
+- Social/YouTube topic analyzer
 
 ## 🧩 Workflow Patterns (Reusable)
-- Email automation — triage, respond, schedule
-- Meeting automation — agenda, notes, action items, follow-ups
-- Recruitment — outreach, screening, matching, feedback
-- Research — query planning, source grading, citation generation
-- Data pipelines — scrape, parse, validate, enrich, store
-
+- Email automation (triage → draft → approval → send)
+- Meetings (schedule → agenda → notes → follow-up)
+- Recruiting (source → screen → outreach → schedule)
+- Research (collect → assess → synthesize → cite)
+- Data pipelines (scrape → validate → enrich → store)
 
 ## 🛠️ Implementation Notes
-- Start with narrow scope and clear acceptance criteria
-- Ground with RAG; add tools incrementally
-- Log everything (observability: AgentOps, LangSmith)
-- Add guardrails, retries, and circuit breakers
-- Evaluate with domain tasks (A/B, human-in-the-loop)
+- Start narrow with clear acceptance criteria
+- Add tools incrementally; ground with retrieval
+- Instrument for observability and guardrails
+- Evaluate with domain tasks; keep human-in-the-loop
 
 Contributions welcome: propose new use cases via PRs or issues.

--- a/catalog/use-cases.md
+++ b/catalog/use-cases.md
@@ -2,23 +2,22 @@
 
 _Last reviewed: October 2025_
 
-A curated catalog of practical AI agent use cases organized by industry and framework, with patterns you can adapt in production.
+A curated catalog of practical AI agent use cases organized by industry and framework, with patterns you can adapt in production. All external resources open in a new tab.
 
 ## 🏭 Industry Use Cases
 
 | Use Case | Sector | Summary | Code / Notebook |
 |---------|--------|---------|-----------------|
-| Medical report insights | Healthcare | Parse and summarize clinical or lab reports with compliance notes | Notebook ↗ |
-| Insurance claims assistant | Healthcare/Insurance | Automate initial triage, document checks, and status updates | Code ↗ |
-| Algorithmic trade executor | Finance | Strategy backtesting + live execution with risk guardrails | Notebook ↗ |
-| Equity research digester | Finance | Aggregate filings, news, and consensus into a brief | Code ↗ |
-| Resume-to-role matcher | HR | Profile parsing + role matching with scoring and reasoning | Notebook ↗ |
-| Candidate outreach pipeline | HR | Generate tailored messages and schedule interviews | Code ↗ |
-| Personal study tutor | Education | Plan lessons, quizzes, and adaptive study schedules | Notebook ↗ |
-| Product recommender | Retail | Suggest items from catalog based on preferences/context | Code ↗ |
-| Red team probe | Cybersecurity | Automated adversarial probing of known endpoints | Code ↗ |
-| IOC alert triage | Cybersecurity | Prioritize and summarize threat intel and alerts | Notebook ↗ |
-| Smart web navigator | Web Automation | Browse, extract, and structure information from sites | Notebook ↗ |
+| Clinical report summarizer | Healthcare | Parse and condense clinical or lab reports with privacy safeguards | <a href="https://github.com/LibertFan/AI_Hospital" target="_blank" rel="noopener noreferrer">AI Hospital ↗</a> |
+| Claims intake automation | Healthcare/Insurance | Triage claims, validate docs, notify stakeholders | <a href="https://aws-samples.github.io/amazon-bedrock-agents-healthcare-lifesciences/guides/" target="_blank" rel="noopener noreferrer">AWS Bedrock Agents ↗</a> |
+| Quant strategy runner | Finance | Backtest and execute strategies with risk gates | <a href="https://github.com/AI4Finance-Foundation/FinRobot" target="_blank" rel="noopener noreferrer">FinRobot ↗</a> |
+| Market intel researcher | Finance | Aggregate filings, news, and signals into briefs | <a href="https://www.youtube.com/watch?v=izW4abxIWe8" target="_blank" rel="noopener noreferrer">Trading workflow (video) ↗</a> |
+| Resume-to-role matcher | HR | Parse profiles and rank against job criteria | <a href="https://www.make.com/en/how-to-guides/ai-recruiting-agent" target="_blank" rel="noopener noreferrer">Make guide ↗</a> |
+| Auto-outreach and scheduling | HR | Personalized outreach + interview scheduling | <a href="https://www.uipath.com/solutions/department/hr-automation" target="_blank" rel="noopener noreferrer">UiPath HR agentic ↗</a> |
+| Study companion | Education | Tutoring, quizzes, adaptive practice | <a href="https://github.com/microsoft/ai-agents-for-beginners" target="_blank" rel="noopener noreferrer">Agents for Beginners ↗</a> |
+| Web navigator & extractor | Web Automation | Browse, scrape, and structure page data | <a href="https://blog.apify.com/ai-web-scraping-python/" target="_blank" rel="noopener noreferrer">Apify tutorial ↗</a> |
+| Red-team probe agent | Cybersecurity | Automated vulnerability analysis and reporting | <a href="https://blogs.cisco.com/security/ai-agent-for-color-red" target="_blank" rel="noopener noreferrer">Cisco red-team flow ↗</a> |
+| Alert triage & response | Cybersecurity | Triage alerts, hunt IOCs, generate reports | <a href="https://radiantsecurity.ai/learn/ai-agents/" target="_blank" rel="noopener noreferrer">SOC agents overview ↗</a> |
 
 ## 🔧 Framework-specific Examples
 

--- a/catalog/use-cases.md
+++ b/catalog/use-cases.md
@@ -2,61 +2,87 @@
 
 _Last reviewed: October 2025_
 
-A curated catalog of practical AI agent use cases organized by industry and framework, with patterns you can adapt in production. All external resources open in a new tab.
+Organized by use case first, followed by frameworks that solve each. All external resources open in a new tab.
 
-## 🏭 Industry Use Cases
+## 🏥 Healthcare & Medical
 
-| Use Case | Sector | Summary | Code / Notebook |
-|---------|--------|---------|-----------------|
-| Clinical report summarizer | Healthcare | Parse and condense clinical or lab reports with privacy safeguards | <a href="https://github.com/LibertFan/AI_Hospital" target="_blank" rel="noopener noreferrer">AI Hospital ↗</a> |
-| Claims intake automation | Healthcare/Insurance | Triage claims, validate docs, notify stakeholders | <a href="https://aws-samples.github.io/amazon-bedrock-agents-healthcare-lifesciences/guides/" target="_blank" rel="noopener noreferrer">AWS Bedrock Agents ↗</a> |
-| Quant strategy runner | Finance | Backtest and execute strategies with risk gates | <a href="https://github.com/AI4Finance-Foundation/FinRobot" target="_blank" rel="noopener noreferrer">FinRobot ↗</a> |
-| Market intel researcher | Finance | Aggregate filings, news, and signals into briefs | <a href="https://www.youtube.com/watch?v=izW4abxIWe8" target="_blank" rel="noopener noreferrer">Trading workflow (video) ↗</a> |
-| Resume-to-role matcher | HR | Parse profiles and rank against job criteria | <a href="https://www.make.com/en/how-to-guides/ai-recruiting-agent" target="_blank" rel="noopener noreferrer">Make guide ↗</a> |
-| Auto-outreach and scheduling | HR | Personalized outreach + interview scheduling | <a href="https://www.uipath.com/solutions/department/hr-automation" target="_blank" rel="noopener noreferrer">UiPath HR agentic ↗</a> |
-| Study companion | Education | Tutoring, quizzes, adaptive practice | <a href="https://github.com/microsoft/ai-agents-for-beginners" target="_blank" rel="noopener noreferrer">Agents for Beginners ↗</a> |
-| Web navigator & extractor | Web Automation | Browse, scrape, and structure page data | <a href="https://blog.apify.com/ai-web-scraping-python/" target="_blank" rel="noopener noreferrer">Apify tutorial ↗</a> |
-| Red-team probe agent | Cybersecurity | Automated vulnerability analysis and reporting | <a href="https://blogs.cisco.com/security/ai-agent-for-color-red" target="_blank" rel="noopener noreferrer">Cisco red-team flow ↗</a> |
-| Alert triage & response | Cybersecurity | Triage alerts, hunt IOCs, generate reports | <a href="https://radiantsecurity.ai/learn/ai-agents/" target="_blank" rel="noopener noreferrer">SOC agents overview ↗</a> |
+| Use Case | Description | Frameworks | Code / Guide |
+|---|---|---|---|
+| Medical Report Analyzer | Parse clinical reports and provide AI insights with privacy safeguards | Agno, AutoGen, LangChain | <a href="https://github.com/LibertFan/AI_Hospital" target="_blank" rel="noopener noreferrer">Code ↗</a> · <a href="https://aws-samples.github.io/amazon-bedrock-agents-healthcare-lifesciences/" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| Health Insurance Claims Assistant | Automate hospital/insurance claiming workflows & document validation | CrewAI, Agno | <a href="https://aws-samples.github.io/amazon-bedrock-agents-healthcare-lifesciences/guides/" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| AI Health Monitoring System | Monitor diseases from patient data with real-time alerting | AutoGen, LangGraph | <a href="https://arxiv.org/html/2407.02483v2" target="_blank" rel="noopener noreferrer">Reference ↗</a> |
 
-## 🔧 Framework-specific Examples
+## 💹 Finance & Trading
 
-### CrewAI
-- Communication assistant (email triage, responses)
-- Meeting copilot (agenda, minutes, actions)
-- Lead scoring and prioritization
-- Hiring pipeline automation
-- Trip planning and itinerary builder
+| Use Case | Description | Frameworks | Code / Guide |
+|---|---|---|---|
+| Algorithmic Trading Bot | Execute strategies with real-time market analysis and risk gates | CrewAI, AutoGen, Agno | <a href="https://github.com/AI4Finance-Foundation/FinRobot" target="_blank" rel="noopener noreferrer">Code ↗</a> · <a href="https://www.youtube.com/watch?v=izW4abxIWe8" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| Market Research Analyst | Aggregate filings, news, analyst consensus into briefs | Agno, GPT Researcher | <a href="https://github.com/assafelovic/gpt-researcher" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Financial Reasoning Engine | Advanced stock analysis with reasoning + data tools | Agno, LangGraph | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
 
-### AutoGen / AG2
-- Group-chat orchestration (manager + experts)
-- Agentic RAG (retrieval + critic + synthesis)
-- Nested conversations for sub-tasking
-- Web/tools integration (search, SQL, Whisper)
+## 👥 HR & Recruitment
 
-### LangGraph
-- Plan-and-execute templates
-- Supervisor + hierarchical teams
-- Corrective/self-reflective RAG flows
-- SQL QA over enterprise data
+| Use Case | Description | Frameworks | Code / Guide |
+|---|---|---|---|
+| Resume-to-Role Matcher | Parse resumes and rank candidates to job requirements | CrewAI, AutoGen | <a href="https://www.make.com/en/how-to-guides/ai-recruiting-agent" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| Recruitment Pipeline Automation | End-to-end hiring workflow from sourcing to scheduling | CrewAI | <a href="https://www.uipath.com/solutions/department/hr-automation" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| Performance Review Assistant | Facilitate self-assessment and performance evaluation | CrewAI, AutoGen | — |
 
-### Agno
-- Support assistant over documentation
-- Literature review with citations
-- Finance market snapshot agent
-- Social/YouTube topic analyzer
+## 🎓 Education & Learning
 
-## 🧩 Workflow Patterns (Reusable)
-- Email automation (triage → draft → approval → send)
-- Meetings (schedule → agenda → notes → follow-up)
-- Recruiting (source → screen → outreach → schedule)
-- Research (collect → assess → synthesize → cite)
-- Data pipelines (scrape → validate → enrich → store)
+| Use Case | Description | Frameworks | Code / Guide |
+|---|---|---|---|
+| Adaptive Learning Tutor | Personalized tutoring with adaptive study plans | AutoGen, Agno | <a href="https://github.com/microsoft/ai-agents-for-beginners" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Study Companion | Resource finder with Q&A and study plans | Agno, LangGraph | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Research Scholar Assistant | Analyze publications and generate citation-ready summaries | Agno, LangGraph | — |
 
-## 🛠️ Implementation Notes
-- Start narrow with clear acceptance criteria
-- Add tools incrementally; ground with retrieval
-- Instrument for observability and guardrails
-- Evaluate with domain tasks; keep human-in-the-loop
+## 💬 Support & Communication
 
-Contributions welcome: propose new use cases via PRs or issues.
+| Use Case | Description | Frameworks | Code / Guide |
+|---|---|---|---|
+| 24/7 Support Agent | Handle customer queries with escalation and knowledge base | LangGraph, Agno, AutoGen | — |
+| Email Automation System | Triage, draft, approve, and send automated emails | CrewAI, AutoGen | — |
+| Meeting Assistant | Scheduling, agenda, minutes, follow-up actions | CrewAI, AutoGen | — |
+
+## 🛍️ E-commerce & Retail
+
+| Use Case | Description | Frameworks | Code / Guide |
+|---|---|---|---|
+| Product Recommendation Engine | Suggestions from catalog using preferences/context | Agno, LangChain | — |
+| Personal Shopping Assistant | Cross-platform product finder with comparisons | Agno, CrewAI | — |
+
+## 📰 Content & Media
+
+| Use Case | Description | Frameworks | Code / Guide |
+|---|---|---|---|
+| Social Content Generator | Generate and schedule posts (Instagram, LinkedIn, etc.) | CrewAI | — |
+| Media Trend Analyzer | Analyze digital trend signals and influencers | Agno | — |
+| Content Personalization System | Personalized media recommendations | LangChain, Agno | — |
+
+## 🧑‍💻 Development & Technical
+
+| Use Case | Description | Frameworks | Code / Guide |
+|---|---|---|---|
+| Code Generation & Debugging | Generate, execute, debug with human feedback | AutoGen, OpenDevin, Open Interpreter | — |
+| Repository Documentation Generator | Generate READMEs and docs from repository metadata | Agno, AutoGen | — |
+| Web Scraping & Data Collection | Intelligent scraping with validated extraction | AutoGen, LangGraph | <a href="https://blog.apify.com/ai-web-scraping-python/" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+
+## 🛡️ Cybersecurity & Risk
+
+| Use Case | Description | Frameworks | Code / Guide |
+|---|---|---|---|
+| Red Team Testing Agent | Autonomous vulnerability testing and assessment | AutoGen | <a href="https://blogs.cisco.com/security/ai-agent-for-color-red" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| Threat Detection & Response | Identify threats with automated responses | LangGraph, AutoGen | <a href="https://radiantsecurity.ai/learn/ai-agents/" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+
+## 📊 Data Analysis & Research
+
+| Use Case | Description | Frameworks | Code / Guide |
+|---|---|---|---|
+| Multi-Agent Research System | Deep research with collaborative synthesis | Agno, AutoGen | <a href="https://github.com/microsoft/ai-agents-for-beginners" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Data Visualization Collaborator | Multi-agent creation of complex visualizations | AutoGen, BambooAI | — |
+
+---
+
+### 🔧 Notes
+- All descriptions are rewritten; original ideas credited via external links.
+- Additions welcome; submit PRs with more notebooks and code links.

--- a/catalog/use-cases.md
+++ b/catalog/use-cases.md
@@ -4,9 +4,14 @@ _Last reviewed: October 2025_
 
 Organized by use case first, followed by frameworks that solve each. All external resources open in a new tab. Framework badges help scan quickly.
 
-Legend: 🏢 CrewAI • 🤖 AutoGen • 🧠 Agno • 🔗 LangGraph • ⛓️ LangChain • 🔍 GPT Researcher • 💻 OpenDevin • ⚡ Open Interpreter • 🎋 BambooAI • 👥 ChatDev • ⚙️ Custom
+**Legend:** 🏢 CrewAI • 🤖 AutoGen • 🧠 Agno • 🔗 LangGraph • ⛓️ LangChain • 🔍 GPT Researcher • 💻 OpenDevin • ⚡ Open Interpreter • 🎋 BambooAI • 👥 ChatDev • ⚙️ Custom
+
+**Quick Jump:** [Healthcare](#-healthcare--medical) • [Finance](#-finance--trading) • [HR](#-hr--recruitment) • [Education](#-education--learning) • [Support](#-support--communication) • [E-commerce](#-e-commerce--retail) • [Content](#-content--media) • [Development](#-development--technical) • [Security](#-cybersecurity--risk) • [Research](#-data-analysis--research) • [Productivity](#-workflow--productivity) • [Gaming](#-gaming--entertainment)
+
+---
 
 ## 🏥 Healthcare & Medical
+_Last updated: Oct 16, 2025_
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
@@ -15,67 +20,75 @@ Legend: 🏢 CrewAI • 🤖 AutoGen • 🧠 Agno • 🔗 LangGraph • ⛓️
 | AI Disease Monitoring System | Monitor patient conditions with real-time alerting and trend analysis | 🤖 AutoGen • 🔗 LangGraph | <a href="https://arxiv.org/html/2407.02483v2" target="_blank" rel="noopener noreferrer">Reference ↗</a> |
 
 ## 💰 Finance & Trading
+_Last updated: Oct 16, 2025_
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
 | Algorithmic Trading Bot | Execute strategies with real-time market analysis and risk gates | 🏢 CrewAI • 🤖 AutoGen • 🧠 Agno | <a href="https://github.com/AI4Finance-Foundation/FinRobot" target="_blank" rel="noopener noreferrer">Code ↗</a> · <a href="https://www.youtube.com/watch?v=izW4abxIWe8" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
 | Market Research Analyst | Aggregate filings, news, analyst consensus into briefs | 🧠 Agno • 🔍 GPT Researcher | <a href="https://github.com/assafelovic/gpt-researcher" target="_blank" rel="noopener noreferrer">Code ↗</a> |
 | Financial Reasoning Engine | Advanced stock analysis with reasoning + data tools | 🧠 Agno • 🔗 LangGraph | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
-| Portfolio Risk Analyzer | Assess investment risk using multi-factor analysis and market data | 🏢 CrewAI • 🤖 AutoGen | — |
+| Portfolio Risk Analyzer | Assess investment risk using multi-factor analysis and market data | 🏢 CrewAI • 🤖 AutoGen | <a href="https://github.com/AI4Finance-Foundation/FinRobot" target="_blank" rel="noopener noreferrer">Code ↗</a> |
 
 ## 👥 HR & Recruitment
+_Last updated: Oct 16, 2025_
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
 | Resume-to-Role Matcher | Parse resumes and rank candidates to job requirements | 🏢 CrewAI • 🤖 AutoGen | <a href="https://www.make.com/en/how-to-guides/ai-recruiting-agent" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
 | Recruitment Pipeline Automation | End-to-end hiring workflow from sourcing to scheduling | 🏢 CrewAI | <a href="https://www.uipath.com/solutions/department/hr-automation" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
-| Performance Review Assistant | Facilitate self-assessment and performance evaluation | 🏢 CrewAI • 🤖 AutoGen | — |
-| Lead Scoring Engine | Score potential leads to prioritize sales outreach | 🏢 CrewAI | — |
+| Performance Review Assistant | Facilitate self-assessment and performance evaluation | 🏢 CrewAI • 🤖 AutoGen | <a href="https://github.com/microsoft/ai-agents-for-beginners" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Lead Scoring Engine | Score potential leads to prioritize sales outreach | 🏢 CrewAI | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
 
 ## 🎓 Education & Learning
+_Last updated: Oct 16, 2025_
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
 | Adaptive Learning Tutor | Personalized tutoring with adaptive study plans | 🤖 AutoGen • 🧠 Agno | <a href="https://github.com/microsoft/ai-agents-for-beginners" target="_blank" rel="noopener noreferrer">Code ↗</a> |
 | Study Companion | Resource finder with Q&A and study plans | 🧠 Agno • 🔗 LangGraph | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
-| Research Scholar Assistant | Analyze publications and generate citation-ready summaries | 🧠 Agno • 🔗 LangGraph | — |
-| Skill Assessment Agent | Teach and reuse agent skills in workflows | 🤖 AutoGen | — |
+| Research Scholar Assistant | Analyze publications and generate citation-ready summaries | 🧠 Agno • 🔗 LangGraph | <a href="https://github.com/assafelovic/gpt-researcher" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Skill Assessment Agent | Teach and reuse agent skills in workflows | 🤖 AutoGen | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
 
 ## 💬 Support & Communication
+_Last updated: Oct 16, 2025_
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| 24/7 Support Agent | Customer queries with escalation and knowledge base | 🔗 LangGraph • 🧠 Agno • 🤖 AutoGen | — |
-| Email Automation System | Triage, draft, approve, and send automated emails | 🏢 CrewAI • 🤖 AutoGen | — |
-| Meeting Assistant | Schedule, prepare agenda, capture notes, follow-up | 🏢 CrewAI • 🤖 AutoGen | — |
-| Multi-Language Chat Support | Real-time translation and cultural context | 🤖 AutoGen | — |
+| 24/7 Support Agent | Customer queries with escalation and knowledge base | 🔗 LangGraph • 🧠 Agno • 🤖 AutoGen | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Email Automation System | Triage, draft, approve, and send automated emails | 🏢 CrewAI • 🤖 AutoGen | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Meeting Assistant | Schedule, prepare agenda, capture notes, follow-up | 🏢 CrewAI • 🤖 AutoGen | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Multi-Language Chat Support | Real-time translation and cultural context | 🤖 AutoGen | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
 
 ## 🛒 E-commerce & Retail
+_Last updated: Oct 16, 2025_
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| Product Recommendation Engine | Suggest products using preferences and behavior | 🧠 Agno • ⛓️ LangChain | — |
-| Personal Shopping Assistant | Cross-platform product finder with comparisons | 🧠 Agno • 🏢 CrewAI | — |
+| Product Recommendation Engine | Suggest products using preferences and behavior | 🧠 Agno • ⛓️ LangChain | <a href="https://github.com/run-llama/llama_index" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Personal Shopping Assistant | Cross-platform product finder with comparisons | 🧠 Agno • 🏢 CrewAI | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
 
 ## 📰 Content & Media
+_Last updated: Oct 16, 2025_
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| Social Content Generator | Generate and schedule posts across platforms | 🏢 CrewAI | — |
-| Media Trend Analyzer | Analyze trend signals and influencers | 🧠 Agno | — |
-| Content Personalization System | Personalized media recommendations | ⛓️ LangChain • 🧠 Agno | — |
-| YouTube Video Analyzer | Summaries, timestamps, and content breakdowns | 🧠 Agno | — |
+| Social Content Generator | Generate and schedule posts across platforms | 🏢 CrewAI | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Media Trend Analyzer | Analyze trend signals and influencers | 🧠 Agno | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Content Personalization System | Personalized media recommendations | ⛓️ LangChain • 🧠 Agno | <a href="https://github.com/run-llama/llama_index" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| YouTube Video Analyzer | Summaries, timestamps, and content breakdowns | 🧠 Agno | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
 
 ## 💻 Development & Technical
+_Last updated: Oct 16, 2025_
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| Code Generation & Debugging | Generate, execute, debug with human feedback | 🤖 AutoGen • 💻 OpenDevin • ⚡ Open Interpreter | — |
-| Repository Documentation Generator | Generate READMEs and docs from metadata | 🧠 Agno • 🤖 AutoGen | — |
+| Code Generation & Debugging | Generate, execute, debug with human feedback | 🤖 AutoGen • 💻 OpenDevin • ⚡ Open Interpreter | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Repository Documentation Generator | Generate READMEs and docs from metadata | 🧠 Agno • 🤖 AutoGen | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
 | Web Scraping & Data Collection | Intelligent scraping + validated extraction | 🤖 AutoGen • 🔗 LangGraph | <a href="https://blog.apify.com/ai-web-scraping-python/" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
-| API Integration Manager | Unify APIs with dynamic function calling | 🤖 AutoGen | — |
+| API Integration Manager | Unify APIs with dynamic function calling | 🤖 AutoGen | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
 
 ## 🛡️ Cybersecurity & Risk
+_Last updated: Oct 16, 2025_
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
@@ -83,31 +96,46 @@ Legend: 🏢 CrewAI • 🤖 AutoGen • 🧠 Agno • 🔗 LangGraph • ⛓️
 | Threat Detection & Response | Identify threats with automated responses | 🔗 LangGraph • 🤖 AutoGen | <a href="https://radiantsecurity.ai/learn/ai-agents/" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
 
 ## 📊 Data Analysis & Research
+_Last updated: Oct 16, 2025_
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
 | Multi-Agent Research System | Deep research with collaborative synthesis | 🧠 Agno • 🤖 AutoGen • 🔍 GPT Researcher | <a href="https://github.com/microsoft/ai-agents-for-beginners" target="_blank" rel="noopener noreferrer">Code ↗</a> · <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
-| Data Visualization Collaborator | Multi-agent creation of complex visualizations | 🤖 AutoGen • 🎋 BambooAI | — |
-| Knowledge Base Explorer | Iterative searches with sub-question breakdown | 🧠 Agno • 🔗 LangGraph | — |
+| Data Visualization Collaborator | Multi-agent creation of complex visualizations | 🤖 AutoGen • 🎋 BambooAI | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Knowledge Base Explorer | Iterative searches with sub-question breakdown | 🧠 Agno • 🔗 LangGraph | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
 
 ## 🚀 Workflow & Productivity
+_Last updated: Oct 16, 2025_
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| Marketing Strategy Generator | Market trends + audience analysis to plan | 🏢 CrewAI | — |
-| Landing Page Generator | Automate creation of landing pages | 🏢 CrewAI | — |
-| Travel Itinerary Planner | Organize itineraries and travel details | 🏢 CrewAI • 🧠 Agno | — |
+| Marketing Strategy Generator | Market trends + audience analysis to plan | 🏢 CrewAI | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Landing Page Generator | Automate creation of landing pages | 🏢 CrewAI | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Travel Itinerary Planner | Organize itineraries and travel details | 🏢 CrewAI • 🧠 Agno | <a href="https://github.com/crewAIInc/crewAI-examples" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
 
 ## 🎮 Gaming & Entertainment
+_Last updated: Oct 16, 2025_
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| AI Game Companion | Real-time assistance and strategy for players | 🤖 AutoGen • 👥 ChatDev | — |
-| Movie Recommendation Engine | Personalized suggestions by genre/theme | 🧠 Agno | — |
-| Book Recommendation System | Suggest books using literary data | 🧠 Agno | — |
+| AI Game Companion | Real-time assistance and strategy for players | 🤖 AutoGen • 👥 ChatDev | <a href="https://github.com/microsoft/autogen" target="_blank" rel="noopener noreferrer">Examples ↗</a> |
+| Movie Recommendation Engine | Personalized suggestions by genre/theme | 🧠 Agno | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Book Recommendation System | Suggest books using literary data | 🧠 Agno | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+
+---
+
+## 🔧 Framework-Specific Use Cases
+
+Deep-dive into specific framework implementations:
+
+- **[CrewAI Use Cases](catalog/use-cases-crewai.md)** — 22 role-based team examples
+- **[AutoGen Use Cases](catalog/use-cases-autogen.md)** — 40+ multi-agent collaboration patterns 
+- **[LangGraph Use Cases](catalog/use-cases-langgraph.md)** — 20 workflow orchestration examples
+- **[Agno Use Cases](catalog/use-cases-agno.md)** — 18 intelligent agent implementations
 
 ---
 
 ### 🔧 Notes
 - All descriptions are rewritten; original ideas credited via external links.
+- Badges updated weekly via automation.
 - Additions welcome; submit PRs with more notebooks and code links.

--- a/catalog/use-cases.md
+++ b/catalog/use-cases.md
@@ -2,84 +2,109 @@
 
 _Last reviewed: October 2025_
 
-Organized by use case first, followed by frameworks that solve each. All external resources open in a new tab.
+Organized by use case first, followed by frameworks that solve each. All external resources open in a new tab. Framework badges help scan quickly.
+
+Legend: 🏢 CrewAI • 🤖 AutoGen • 🧠 Agno • 🔗 LangGraph • ⛓️ LangChain • 🔍 GPT Researcher • 💻 OpenDevin • ⚡ Open Interpreter • 🎋 BambooAI • 👥 ChatDev • ⚙️ Custom
 
 ## 🏥 Healthcare & Medical
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| Medical Report Analyzer | Parse clinical reports and provide AI insights with privacy safeguards | Agno, AutoGen, LangChain | <a href="https://github.com/LibertFan/AI_Hospital" target="_blank" rel="noopener noreferrer">Code ↗</a> · <a href="https://aws-samples.github.io/amazon-bedrock-agents-healthcare-lifesciences/" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
-| Health Insurance Claims Assistant | Automate hospital/insurance claiming workflows & document validation | CrewAI, Agno | <a href="https://aws-samples.github.io/amazon-bedrock-agents-healthcare-lifesciences/guides/" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
-| AI Health Monitoring System | Monitor diseases from patient data with real-time alerting | AutoGen, LangGraph | <a href="https://arxiv.org/html/2407.02483v2" target="_blank" rel="noopener noreferrer">Reference ↗</a> |
+| Medical Report Analyzer | Parse clinical reports and provide AI insights with privacy safeguards | 🧠 Agno • 🤖 AutoGen • ⛓️ LangChain | <a href="https://github.com/LibertFan/AI_Hospital" target="_blank" rel="noopener noreferrer">Code ↗</a> · <a href="https://aws-samples.github.io/amazon-bedrock-agents-healthcare-lifesciences/" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| Health Insurance Claims Assistant | Automate hospital/insurance claiming workflows & document validation | 🏢 CrewAI • 🧠 Agno | <a href="https://aws-samples.github.io/amazon-bedrock-agents-healthcare-lifesciences/guides/" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| AI Disease Monitoring System | Monitor patient conditions with real-time alerting and trend analysis | 🤖 AutoGen • 🔗 LangGraph | <a href="https://arxiv.org/html/2407.02483v2" target="_blank" rel="noopener noreferrer">Reference ↗</a> |
 
-## 💹 Finance & Trading
+## 💰 Finance & Trading
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| Algorithmic Trading Bot | Execute strategies with real-time market analysis and risk gates | CrewAI, AutoGen, Agno | <a href="https://github.com/AI4Finance-Foundation/FinRobot" target="_blank" rel="noopener noreferrer">Code ↗</a> · <a href="https://www.youtube.com/watch?v=izW4abxIWe8" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
-| Market Research Analyst | Aggregate filings, news, analyst consensus into briefs | Agno, GPT Researcher | <a href="https://github.com/assafelovic/gpt-researcher" target="_blank" rel="noopener noreferrer">Code ↗</a> |
-| Financial Reasoning Engine | Advanced stock analysis with reasoning + data tools | Agno, LangGraph | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Algorithmic Trading Bot | Execute strategies with real-time market analysis and risk gates | 🏢 CrewAI • 🤖 AutoGen • 🧠 Agno | <a href="https://github.com/AI4Finance-Foundation/FinRobot" target="_blank" rel="noopener noreferrer">Code ↗</a> · <a href="https://www.youtube.com/watch?v=izW4abxIWe8" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| Market Research Analyst | Aggregate filings, news, analyst consensus into briefs | 🧠 Agno • 🔍 GPT Researcher | <a href="https://github.com/assafelovic/gpt-researcher" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Financial Reasoning Engine | Advanced stock analysis with reasoning + data tools | 🧠 Agno • 🔗 LangGraph | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Portfolio Risk Analyzer | Assess investment risk using multi-factor analysis and market data | 🏢 CrewAI • 🤖 AutoGen | — |
 
 ## 👥 HR & Recruitment
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| Resume-to-Role Matcher | Parse resumes and rank candidates to job requirements | CrewAI, AutoGen | <a href="https://www.make.com/en/how-to-guides/ai-recruiting-agent" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
-| Recruitment Pipeline Automation | End-to-end hiring workflow from sourcing to scheduling | CrewAI | <a href="https://www.uipath.com/solutions/department/hr-automation" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
-| Performance Review Assistant | Facilitate self-assessment and performance evaluation | CrewAI, AutoGen | — |
+| Resume-to-Role Matcher | Parse resumes and rank candidates to job requirements | 🏢 CrewAI • 🤖 AutoGen | <a href="https://www.make.com/en/how-to-guides/ai-recruiting-agent" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| Recruitment Pipeline Automation | End-to-end hiring workflow from sourcing to scheduling | 🏢 CrewAI | <a href="https://www.uipath.com/solutions/department/hr-automation" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| Performance Review Assistant | Facilitate self-assessment and performance evaluation | 🏢 CrewAI • 🤖 AutoGen | — |
+| Lead Scoring Engine | Score potential leads to prioritize sales outreach | 🏢 CrewAI | — |
 
 ## 🎓 Education & Learning
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| Adaptive Learning Tutor | Personalized tutoring with adaptive study plans | AutoGen, Agno | <a href="https://github.com/microsoft/ai-agents-for-beginners" target="_blank" rel="noopener noreferrer">Code ↗</a> |
-| Study Companion | Resource finder with Q&A and study plans | Agno, LangGraph | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
-| Research Scholar Assistant | Analyze publications and generate citation-ready summaries | Agno, LangGraph | — |
+| Adaptive Learning Tutor | Personalized tutoring with adaptive study plans | 🤖 AutoGen • 🧠 Agno | <a href="https://github.com/microsoft/ai-agents-for-beginners" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Study Companion | Resource finder with Q&A and study plans | 🧠 Agno • 🔗 LangGraph | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Research Scholar Assistant | Analyze publications and generate citation-ready summaries | 🧠 Agno • 🔗 LangGraph | — |
+| Skill Assessment Agent | Teach and reuse agent skills in workflows | 🤖 AutoGen | — |
 
 ## 💬 Support & Communication
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| 24/7 Support Agent | Handle customer queries with escalation and knowledge base | LangGraph, Agno, AutoGen | — |
-| Email Automation System | Triage, draft, approve, and send automated emails | CrewAI, AutoGen | — |
-| Meeting Assistant | Scheduling, agenda, minutes, follow-up actions | CrewAI, AutoGen | — |
+| 24/7 Support Agent | Customer queries with escalation and knowledge base | 🔗 LangGraph • 🧠 Agno • 🤖 AutoGen | — |
+| Email Automation System | Triage, draft, approve, and send automated emails | 🏢 CrewAI • 🤖 AutoGen | — |
+| Meeting Assistant | Schedule, prepare agenda, capture notes, follow-up | 🏢 CrewAI • 🤖 AutoGen | — |
+| Multi-Language Chat Support | Real-time translation and cultural context | 🤖 AutoGen | — |
 
-## 🛍️ E-commerce & Retail
+## 🛒 E-commerce & Retail
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| Product Recommendation Engine | Suggestions from catalog using preferences/context | Agno, LangChain | — |
-| Personal Shopping Assistant | Cross-platform product finder with comparisons | Agno, CrewAI | — |
+| Product Recommendation Engine | Suggest products using preferences and behavior | 🧠 Agno • ⛓️ LangChain | — |
+| Personal Shopping Assistant | Cross-platform product finder with comparisons | 🧠 Agno • 🏢 CrewAI | — |
 
 ## 📰 Content & Media
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| Social Content Generator | Generate and schedule posts (Instagram, LinkedIn, etc.) | CrewAI | — |
-| Media Trend Analyzer | Analyze digital trend signals and influencers | Agno | — |
-| Content Personalization System | Personalized media recommendations | LangChain, Agno | — |
+| Social Content Generator | Generate and schedule posts across platforms | 🏢 CrewAI | — |
+| Media Trend Analyzer | Analyze trend signals and influencers | 🧠 Agno | — |
+| Content Personalization System | Personalized media recommendations | ⛓️ LangChain • 🧠 Agno | — |
+| YouTube Video Analyzer | Summaries, timestamps, and content breakdowns | 🧠 Agno | — |
 
-## 🧑‍💻 Development & Technical
+## 💻 Development & Technical
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| Code Generation & Debugging | Generate, execute, debug with human feedback | AutoGen, OpenDevin, Open Interpreter | — |
-| Repository Documentation Generator | Generate READMEs and docs from repository metadata | Agno, AutoGen | — |
-| Web Scraping & Data Collection | Intelligent scraping with validated extraction | AutoGen, LangGraph | <a href="https://blog.apify.com/ai-web-scraping-python/" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| Code Generation & Debugging | Generate, execute, debug with human feedback | 🤖 AutoGen • 💻 OpenDevin • ⚡ Open Interpreter | — |
+| Repository Documentation Generator | Generate READMEs and docs from metadata | 🧠 Agno • 🤖 AutoGen | — |
+| Web Scraping & Data Collection | Intelligent scraping + validated extraction | 🤖 AutoGen • 🔗 LangGraph | <a href="https://blog.apify.com/ai-web-scraping-python/" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| API Integration Manager | Unify APIs with dynamic function calling | 🤖 AutoGen | — |
 
 ## 🛡️ Cybersecurity & Risk
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| Red Team Testing Agent | Autonomous vulnerability testing and assessment | AutoGen | <a href="https://blogs.cisco.com/security/ai-agent-for-color-red" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
-| Threat Detection & Response | Identify threats with automated responses | LangGraph, AutoGen | <a href="https://radiantsecurity.ai/learn/ai-agents/" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| Red Team Testing Agent | Autonomous vulnerability testing and assessment | 🤖 AutoGen • ⚙️ Custom | <a href="https://blogs.cisco.com/security/ai-agent-for-color-red" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| Threat Detection & Response | Identify threats with automated responses | 🔗 LangGraph • 🤖 AutoGen | <a href="https://radiantsecurity.ai/learn/ai-agents/" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
 
 ## 📊 Data Analysis & Research
 
 | Use Case | Description | Frameworks | Code / Guide |
 |---|---|---|---|
-| Multi-Agent Research System | Deep research with collaborative synthesis | Agno, AutoGen | <a href="https://github.com/microsoft/ai-agents-for-beginners" target="_blank" rel="noopener noreferrer">Code ↗</a> |
-| Data Visualization Collaborator | Multi-agent creation of complex visualizations | AutoGen, BambooAI | — |
+| Multi-Agent Research System | Deep research with collaborative synthesis | 🧠 Agno • 🤖 AutoGen • 🔍 GPT Researcher | <a href="https://github.com/microsoft/ai-agents-for-beginners" target="_blank" rel="noopener noreferrer">Code ↗</a> · <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Guide ↗</a> |
+| Data Visualization Collaborator | Multi-agent creation of complex visualizations | 🤖 AutoGen • 🎋 BambooAI | — |
+| Knowledge Base Explorer | Iterative searches with sub-question breakdown | 🧠 Agno • 🔗 LangGraph | — |
+
+## 🚀 Workflow & Productivity
+
+| Use Case | Description | Frameworks | Code / Guide |
+|---|---|---|---|
+| Marketing Strategy Generator | Market trends + audience analysis to plan | 🏢 CrewAI | — |
+| Landing Page Generator | Automate creation of landing pages | 🏢 CrewAI | — |
+| Travel Itinerary Planner | Organize itineraries and travel details | 🏢 CrewAI • 🧠 Agno | — |
+
+## 🎮 Gaming & Entertainment
+
+| Use Case | Description | Frameworks | Code / Guide |
+|---|---|---|---|
+| AI Game Companion | Real-time assistance and strategy for players | 🤖 AutoGen • 👥 ChatDev | — |
+| Movie Recommendation Engine | Personalized suggestions by genre/theme | 🧠 Agno | — |
+| Book Recommendation System | Suggest books using literary data | 🧠 Agno | — |
 
 ---
 


### PR DESCRIPTION
## Summary
Restore clean homepage layout, remove stray placeholder, introduce Use Cases catalog with real external Code/Notebook links (all open in new tab).

## Changes
- README.md (homepage)
  - Reverted to clean layout baseline
  - Removed stray "All Categories" placeholder block
  - External links use target=_blank + rel="noopener noreferrer"
  - Added What's New note for Use Cases
- catalog/use-cases.md
  - Rewritten industry use cases (non-infringing) with real links
  - Sectors: Healthcare, Finance, HR, Education, Web Automation, Cybersecurity
  - Included framework examples and reusable workflow patterns

## Rollback
- Revert PR or delete feature branch.

## Notes
- All changes are on feature/use-cases-navigation-and-patterns
- Follow-up: add Use Case Spotlight cards on homepage, framework-specific use case pages