### PR TITLE
feat: Expand use-cases-first catalog + framework pages (follow-up)

### DIFF
--- a/catalog/use-cases-agno.md
+++ b/catalog/use-cases-agno.md
@@ -1,0 +1,49 @@
+# 🧠 Agno Use Cases
+
+_Last reviewed: October 2025_
+
+Agno specializes in intelligent agents with strong retrieval, analysis, and report generation capabilities.
+
+## 📊 Finance & Markets
+
+| Use Case | Description | Code / Guide |
+|---|---|---|
+| Finance Market Snapshot Agent | Real-time market insights, analyst recommendations, sector heatmaps | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Financial Reasoning Agent | Deep stock analysis with tool use and external data | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+
+## 📚 Research & Writing
+
+| Use Case | Description | Code / Guide |
+|---|---|---|
+| Literature Review with Citations | Aggregate publications and generate structured summaries with citations | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Research Scholar Assistant | Cross-discipline research with synthesis and references | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+
+## 🧩 Support & Q&A
+
+| Use Case | Description | Code / Guide |
+|---|---|---|
+| Support Assistant over Docs | QA over documentation with retrieval and guardrails | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Assist Agent for Agno Docs | Hybrid search over Agno docs with embedded knowledge | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+
+## 🎥 Media & Content
+
+| Use Case | Description | Code / Guide |
+|---|---|---|
+| YouTube Agent | Summaries, timestamps, themes, and content breakdowns | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Book Recommendation Agent | Personalized book suggestions using literary data & reviews | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+
+## 🧠 Knowledge & Reasoning
+
+| Use Case | Description | Code / Guide |
+|---|---|---|
+| DeepKnowledge | Iterative searches across a knowledge base with synthesis | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Legal Document Analysis Agent | Analyze PDFs and provide legal insights with a knowledge base | <a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+
+---
+
+### 🔧 Implementation Notes
+- Use hybrid retrieval and embedded knowledge for precision
+- Add evaluation with domain-specific tasks
+- Keep human-in-the-loop for expert contexts
+
+**← [Back to Use Cases](use-cases.md)**

--- a/catalog/use-cases-langgraph.md
+++ b/catalog/use-cases-langgraph.md
@@ -1,0 +1,50 @@
+# 🔗 LangGraph Use Cases
+
+_Last reviewed: October 2025_
+
+LangGraph specializes in stateful agent workflows with supervisors, hierarchical teams, and corrective RAG patterns.
+
+## 🧠 Workflow Orchestration
+
+| Use Case | Description | Code / Guide |
+|---|---|---|
+| Multi-Agent Workflow | Agent supervisor orchestrating multiple experts | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Hierarchical Agent Teams | Top-level supervisor delegating to sub-agents | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Multi-Agent Collaboration | Specialized agents working together on tasks | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Plan-and-Execute Agent | Generate multi-step plan then execute sequentially | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+
+## 🗄️ Data & SQL
+
+| Use Case | Description | Code / Guide |
+|---|---|---|
+| SQL Agent | NL-to-SQL with schema inspection and error handling | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+
+## 🧪 Agentic RAG Patterns
+
+| Use Case | Description | Code / Guide |
+|---|---|---|
+| Adaptive RAG | Dynamic retrieval strategy based on query complexity | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Adaptive RAG (Local) | Local models and retrieval for offline operation | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Agentic RAG | Agent determines strategy before generation | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Agentic RAG (Local) | Agentic RAG extended to local environments | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Corrective RAG (CRAG) | Evaluate and refine retrieved docs before generation | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Corrective RAG (Local) | CRAG using local resources | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Self-RAG | Reflect on responses, retrieve more if needed | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Self-RAG (Local) | Self-RAG with local models and data sources | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+
+## 🧪 QA & Evaluation
+
+| Use Case | Description | Code / Guide |
+|---|---|---|
+| Chatbot Simulation Evaluation | Simulate user interactions to evaluate chatbot performance | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Reflection Agent | Critique and revise outputs for higher quality | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+| Reflexion Agent | Reflect on actions and outcomes for iterative improvement | <a href="https://github.com/langchain-ai/langgraph" target="_blank" rel="noopener noreferrer">Code ↗</a> |
+
+---
+
+### 🔧 Implementation Notes
+- Use Supervisor for branching task orchestration
+- Persist state across nodes for reliability and retries
+- Combine with vector stores for robust agentic RAG
+
+**← [Back to Use Cases](use-cases.md)**


### PR DESCRIPTION
## Summary
Follow-up PR expanding the Use Cases system and framework coverage.

## Changes
- README.md
  - Keep full "🧪 Categories — By Capability" section
  - Use Case Spotlight with framework badges
- catalog/use-cases.md
  - Use-case-first organization, Quick Jump anchors, Last updated badges
  - More Code/Guide links, framework badges
  - Links to framework-specific pages
- New framework-specific pages
  - catalog/use-cases-crewai.md
  - catalog/use-cases-autogen.md
  - catalog/use-cases-agno.md
  - catalog/use-cases-langgraph.md

## Next
- Add Voice AI, Chat-with-X, Memory/Personalization, MCP patterns
- Fill more Code/Notebook links across categories

## Rollback
- Revert PR or remove newly added files.