### PR TITLE
Add Bernstein to CLI & Terminal Agents

### DIFF
--- a/catalog/cli-agents.md
+++ b/catalog/cli-agents.md
@@ -18,6 +18,7 @@ Developer-focused agents that operate in the shell to automate workflows, genera
 | Amazon Q CLI | https://aws.amazon.com/q/developer/ | CLI | AWS-native dev & ops automation |
 | Continue | https://github.com/continuedev/continue | VS Code | In-IDE agent assistant with tasks |
 | Open Interpreter | https://github.com/KillianLucas/open-interpreter | CLI/Local | Natural language → code execution locally |
+| Bernstein | https://github.com/sipyourdrink-ltd/bernstein | CLI/Orchestrator | Drives 40+ CLI coding agents in parallel git worktrees, deterministic scheduler, HMAC audit log |
 
 Note: Include additional OSS/paid options via PRs.
 


### PR DESCRIPTION
Adds Bernstein to \`catalog/cli-agents.md\` under Key Projects.

- Repo: https://github.com/sipyourdrink-ltd/bernstein
- License: Apache-2.0
- Python orchestrator that drives 40+ CLI coding agents (Claude Code, Codex, Gemini CLI, Cursor, Aider) in parallel git worktrees. One LLM plan call up front, then deterministic scheduling, quality gates, and an HMAC-chained audit log.
- 350 stars, on PyPI as \`bernstein\`.

Sits naturally alongside Goose CLI and Open Interpreter — the orchestrator wraps coding-CLI agents rather than being one itself.

Maintainer disclosure: I am the maintainer.