### PR TITLE
Add Hivekeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Frameworks: 🧠 Agno • 🤖 AutoGen
 | <a href="https://github.com/OpenBMB/ChatDev" target="_blank" rel="noopener noreferrer">ChatDev ↗</a> | Development team | 27K |
 | <a href="https://github.com/ag2ai/fastagency" target="_blank" rel="noopener noreferrer">FastAgency ↗</a> | AG2 production | 1.8K |
 | <a href="https://github.com/openai/swarm" target="_blank" rel="noopener noreferrer">OpenAI Swarm ↗</a> | Lightweight | 15K |
+| <a href="https://github.com/MarlBurroW/hivekeep" target="_blank" rel="noopener noreferrer">Hivekeep ↗</a> | Self-hosted agent team | 26 |
 
 **🚀 Quick Start**: [Multi-Agent Patterns Guide](patterns/multi-agent-patterns.md)
 


### PR DESCRIPTION
Adds Hivekeep to the Multi-Agent Systems table.

Hivekeep is a self-hosted, MIT-licensed platform to run a team of specialized AI agents with persistent memory and a web UI; agents collaborate and build their own tools, mini-apps and plugins; reachable over Telegram, Slack, Discord and Matrix; single container (Bun + SQLite).

Entry matches the table format used in that section.

Disclosure: I am the author of Hivekeep.